### PR TITLE
Add locking and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # python
+*.pyc
 __pycache__
 
 # emacs 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ python-vxi11-server makes your Beagle Bone Black or other linux/python enabled d
 Since VXI-11 specifies how instrument control and data messages transfer over ethernet, libraries such as this one and python-vxi11 do the hard work of setting up and tearing down the link, packing and unpacking the data, and getting the data to the proper endpoints.
 
 Inspired by sonium0's [pyvxi11server](https://github.com/sonium0/pyvxi11server)
+SRQ support by [ulda](https://github.com/ulda)
 
 ### Requirements
   * Ported to Python 3 and tested on the RPi
@@ -27,7 +28,7 @@ The only client library tested against is python-vxi11.  Other clients may expos
 ### Getting started
 Unlike a client library, this 'package' is not installed.  Simply clone and copy into the source tree of your project.
 
-#### server side
+#### Server side
 Run the simple demo clock_device.py program to start an instrument server that responds to a read command with the current time.  Address any portmapper (rpcbind?) issues that may occur.
 
 #### Client side
@@ -45,17 +46,20 @@ For instance here is a very simple VXI-11 time server device that defines an Ins
     import vxi11_server as Vxi11
 
     class TimeDevice(Vxi11.InstrumentDevice):
-        def __init__(self, device_name):
-            super().__init__(device_name)
-
-        def device_read(self):
+        def device_init(self):
+            pass
+			
+        def device_read(self, request_size, term_char, flags, io_timeout):
             '''respond to the device_read rpc: refer to section (B.6.4)
                of the VXI-11 TCP/IP Instrument Protocol Specification'''
+			   
             error = Vxi11.Error.NO_ERROR
-            result = time.strftime("%H:%M:%S +0000", time.gmtime())
-			# In this case, our result is an ascii string. 
-			# encode and return the result as binary (opaque) data for transfer to host
-            return error, result.encode('ascii')
+            reason = Vxi11.ReadRespReason.END
+        
+            # opaque_data is a bytes array, so encode our string appropriately!
+            data = time.strftime("%H:%M:%S +0000", time.gmtime())
+            opaque_data = data.encode("ascii") 
+            return error, reason, data
 
     if __name__ == '__main__':
         # create a server, attach a device, and start a thread to listen for requests
@@ -74,19 +78,18 @@ To access the time server using python-vxi11 as the client library:
 
     instr = vxi11.Instrument("TCPIP::127.0.0.1::inst1::INSTR")
 
-    #read the current time value from the instruments TimeDevice
+    # read the current time value from the instruments TimeDevice
     instr.read()
 
   
 ### Notes
   * be aware that add_device_handler requires a class definition not a class instance as indicated by the lack of parenthesis.  The server instantiates a new instance of your device handler class with each connect request.
   * Write a [python-ivi](https://github.com/python-ivi/python-ivi) driver for your new device
-  * no attempt to harden or benchmark the code has been made.  use at own risk.
+  * no serious attempt to harden, benchmark, or even test the code has been made.  use at own risk.
 
 ### Examples Projects
   * thasti's [GPIB Bridge](https://git.loetlabor-jena.de/thasti/tcpip2instr) project
   
 ### Todo
-  * come up with a simple default locking strategy to place in the InstrumentDevice base class
-  * same for abort functionality
-  * get rid of need for calling super.__init__(). Perhaps add a device_init() function?
+  * add timeout to the lock mechanism
+  * add abort example to explore/verify functionality

--- a/demo_clients/locked_time_client.py
+++ b/demo_clients/locked_time_client.py
@@ -1,0 +1,36 @@
+import time
+
+import vxi11
+
+# with a default instrument, inst0 is implied.
+default_instr = vxi11.Instrument("TCPIP::127.0.0.1::INSTR")
+time_instr = vxi11.Instrument("TCPIP::127.0.0.1::inst1::INSTR")
+#time_instr = vxi11.Instrument("TCPIP::192.168.2.101::TIME::INSTR")
+
+print('The INSTR instrument:')
+
+default_instr.write('*IDN?')
+print(default_instr.read())
+
+print('contains the following devices:')
+default_instr.write('*DEVICE_LIST?')
+print(default_instr.read())
+
+print()
+print('The TIME device has a current value of:')
+while True:
+    try:
+        result = time_instr.lock()
+    except Exception as ex:
+        print(ex)
+    else:
+        is_locked = True
+        while is_locked:
+            try:
+                print(time_instr.read())
+            except Exception as ex:
+                print(ex)
+                is_locked = False
+            time.sleep(1)
+    time.sleep(1)
+    

--- a/demo_servers/srq-device.py
+++ b/demo_servers/srq-device.py
@@ -18,11 +18,11 @@ def signal_handler(signal, frame):
                                         
 class SRQTestDevice(vxi11.InstrumentDevice):
 
-    def __init__(self, device_name):
-        super().__init__(device_name)
+    def device_init(self):
         self.response = ""
-
-    def device_write(self, opaque_data):
+        return
+    
+    def device_write(self, opaque_data, flags, io_timeout):
         "The device_write RPC is used to write data to the specified device"
         error = vxi11.Error.NO_ERROR
 
@@ -33,13 +33,14 @@ class SRQTestDevice(vxi11.InstrumentDevice):
                 break
         return error
 
-    def device_read(self): 
+    def device_read(self, request_size, term_char, flags, io_timeout): 
         "The device_read RPC is used to read data from the device to the controller"
         error = vxi11.Error.NO_ERROR
         aStr=self.response
         self.response=""
+        reason = vxi11.ReadRespReason.END
         # returns opaque_data!
-        return error, aStr.encode("ascii","ignore")
+        return error, reason, aStr.encode("ascii","ignore")
     
     def _addResponse(self,aStr):
         self.response+=aStr

--- a/demo_servers/time-device.py
+++ b/demo_servers/time-device.py
@@ -25,16 +25,23 @@ def signal_handler(signal, frame):
     instr_server.close()
     sys.exit(0)
                                         
-class TimeDevice(Vxi11.InstrumentDevice, Vxi11.instrument_device.InstrumentLock):
-    def __init__(self, device_name, link_id):
-        super().__init__(device_name, link_id)
-        
-    def device_read(self):
+class TimeDevice(Vxi11.InstrumentDevice):
+
+    def device_init(self):
+        #print('TimeDevice: device_init()')
+        return
+    
+    def device_read(self, request_size, term_char, flags, io_timeout):
         '''respond to the device_read rpc: refer to section (B.6.4) 
         of the VXI-11 TCP/IP Instrument Protocol Specification''' 
         error = Vxi11.Error.NO_ERROR
-        result = time.strftime("%H:%M:%S +0000", time.gmtime())
-        return error, result.encode("ascii") # opaque_data is a bystes array, so encode correctly!
+        reason = Vxi11.ReadRespReason.END
+        
+        # opaque_data is a bytes array, so encode correctly!
+        data = time.strftime("%H:%M:%S +0000", time.gmtime())
+        opaque_data = data.encode("ascii") 
+
+        return error, reason, opaque_data
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG)

--- a/demo_servers/time_device.py
+++ b/demo_servers/time_device.py
@@ -24,9 +24,9 @@ def signal_handler(signal, frame):
     instr_server.close()
     sys.exit(0)
                                         
-class TimeDevice(Vxi11.InstrumentDevice):
-    def __init__(self, device_name):
-        super().__init__(device_name)
+class TimeDevice(Vxi11.InstrumentDevice, Vxi11.instrument_device.InstrumentLock):
+    def __init__(self, device_name, link_id):
+        super().__init__(device_name, link_id)
         
     def device_read(self):
         '''respond to the device_read rpc: refer to section (B.6.4) 

--- a/vxi11_server/__init__.py
+++ b/vxi11_server/__init__.py
@@ -1,3 +1,3 @@
 from .vxi11 import Instrument, InterfaceDevice, list_devices, list_resources
 from .instrument_server import InstrumentServer, Error
-from .instrument_device import InstrumentDevice, InstrumentLock
+from .instrument_device import InstrumentDevice, ReadRespReason

--- a/vxi11_server/__init__.py
+++ b/vxi11_server/__init__.py
@@ -1,2 +1,2 @@
 from .instrument_server import InstrumentServer, Error
-from .instrument_device import InstrumentDevice
+from .instrument_device import InstrumentDevice, InstrumentLock

--- a/vxi11_server/instrument_device.py
+++ b/vxi11_server/instrument_device.py
@@ -27,6 +27,11 @@ from . import vxi11
 
 logger = logging.getLogger(__name__)
 
+class ReadRespReason():
+    END = vxi11.RX_END
+    CHR = vxi11.RX_CHR
+    REQCNT = vxi11.RX_REQCNT
+    
 class InstrumentDevice(object):
     '''Base class for Instrument Devices.
 
@@ -39,13 +44,16 @@ class InstrumentDevice(object):
     a device write is a write to the device and device read is a read from the device.
     '''
 
-    def __init__(self, device_name, link_id):
+    def __init__(self, device_name, device_lock):
         self.device_name = device_name
-        self.link_id = link_id
-	self.intr_client = None
+        self.lock = device_lock
+
+        self.intr_client = None
         self.srq_enabled = False
         self.srq_handle = None
-        self.srq_active=False
+        self.srq_active = False
+        
+        return
 
     def create_intr_chan(self,host_addr, host_port, prog_num, prog_vers, prog_family):
         if self.intr_client is not None:
@@ -96,13 +104,18 @@ class InstrumentDevice(object):
     def name(self):
         return self.device_name
 
-    # functions to overwrite when sublcassing start here
+    # functions to overwrite when subclassing start here
+    
+    def device_init(self):
+        "Set the devices idn string etc here.  Called immediately after instance creation."
+        return
     
     def device_abort(self):
+        "The device_abort RPC stops an in-progress call."
         error = vxi11.ERR_NO_ERROR
         return error
     
-    def device_write(self, opaque_data): # 11
+    def device_write(self, opaque_data, flags, io_timeout): # 11
         "The device_write RPC is used to write data to the specified device"
         error = vxi11.ERR_NO_ERROR
 
@@ -117,7 +130,7 @@ class InstrumentDevice(object):
             
         return error
     
-    def device_read(self): #= 12
+    def device_read(self, request_size, term_char, flags, io_timeout): #= 12
         "The device_read RPC is used to read data from the device to the controller"
         error = vxi11.ERR_NO_ERROR
         opaque_data = b""
@@ -130,11 +143,12 @@ class InstrumentDevice(object):
             error = vxi11.ERR_ABORT
         else:
             error = vxi11.ERR_OPERATION_NOT_SUPPORTED
-            
-        result = error, opaque_data
+
+        reason = ReadRespReason.END
+        result = error, reason, opaque_data
         return result
 
-    def device_trigger(self, flags, lock_timeout, io_timeout): # 14, generic params
+    def device_trigger(self, flags, io_timeout): # 14, generic params
         "The device_trigger RPC is used to send a trigger to a device."
         error = vxi11.ERR_NO_ERROR
         
@@ -149,7 +163,7 @@ class InstrumentDevice(object):
             
         return error
 
-    def device_clear(self, flags, lock_timeout, io_timeout): # 15, generic params
+    def device_clear(self, flags, io_timeout): # 15, generic params
         "The device_clear RPC is used to send a device clear to a device"
         error = vxi11.ERR_NO_ERROR
         
@@ -164,7 +178,7 @@ class InstrumentDevice(object):
             
         return error
 
-    def device_remote(self, flags, lock_timeout, io_timeout): # 16, generic params
+    def device_remote(self, flags, io_timeout): # 16, generic params
         "The device_remote RPC is used to place a device in a remote state wherein all programmable local controls are disabled"
         error = vxi11.ERR_NO_ERROR
         
@@ -179,7 +193,7 @@ class InstrumentDevice(object):
             
         return error
 
-    def device_local(self, flags, lock_timeout, io_timeout): # 17, generic params
+    def device_local(self, flags, io_timeout): # 17, generic params
         "The device_local RPC is used to place a device in a local state wherein all programmable local controls are enabled"
         error = vxi11.ERR_NO_ERROR
         
@@ -194,28 +208,6 @@ class InstrumentDevice(object):
             
         return error
 
-    def device_lock(self, flags, lock_timeout): # = 18
-        "The device_lock RPC is used to acquire a device's lock."
-
-        if self.acquire_lock(lock_timeout):
-            error = vxi11.ERR_NO_ERROR
-        elif self.is_locked():
-            error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
-        else:
-            error = vxi11.ERR_ABORT
-            
-        return error
-
-    def device_unlock(self): # = 19
-        "The device_unlock RPC is used to release locks acquired by the device_lock RPC."
-
-        if self.release_lock():
-            error = vxi11.ERR_NO_ERROR
-        else:
-            error = vxi11.ERR_NO_LOCK_HELD_BY_THIS_LINK
-
-        return error
-
     def device_enable_srq(self, enable, handle): # = 20
         "The device_enable_srq RPC is used to enable or disable the sending of device_intr_srq RPCs by thenetwork instrument server"
         error = vxi11.ERR_NO_ERROR
@@ -228,7 +220,7 @@ class InstrumentDevice(object):
             
         return error
 
-    def device_docmd(self, flags, io_timeout, lock_timeout, cmd, network_order, data_size, opaque_data_in): # = 22
+    def device_docmd(self, flags, io_timeout, cmd, network_order, data_size, opaque_data_in): # = 22
         "The device_docmd RPC allows a variety of operations to be executed"
         error = vxi11.ERR_NO_ERROR
         
@@ -244,40 +236,7 @@ class InstrumentDevice(object):
         opaque_data_out = b""
         return error, opaque_data_out
         
-class InstrumentLock(object):
-    # need a locking mechanism to prevent potential race on acquire lock.
-    # timeout not implemented.
-    # the spec plainly states that locking is the responsibility of the core server.
-    # this functionality might better fit in the core server and device_registry.
-    _lock_id = 0
-    
-    def has_lock(self):
-        cls = self.__class__
-        #logger.debug('has_lock() %d, %d', self.link_id, cls._lock_id)
-        return cls._lock_id == 0 or self.link_id == cls._lock_id
-
-    def is_locked(self):
-        cls = self.__class__
-        #logger.debug('has_lock() %d, %d', self.link_id, cls._lock_id)
-        return cls._lock_id != 0
-
-    def acquire_lock(self, lock_timeout):
-        cls = self.__class__
-        logger.debug('locking device %s', self.name())
-        if cls._lock_id == 0:
-            cls._lock_id = self.link_id
-
-        return self.is_locked() and self.has_lock()
-
-    def release_lock(self):
-        cls = self.__class__
-        logger.debug('unlocking device %s', self.name())
-        if cls._lock_id == self.link_id:
-            cls._lock_id = 0
-            return True
-        return False
-    
-class DefaultInstrumentDevice(InstrumentDevice, InstrumentLock):
+class DefaultInstrumentDevice(InstrumentDevice):
     '''The default device is the device registered with the name of "inst0".
 
     The vxi-11 spec expects the default device to respond to the *IDN? command.
@@ -288,23 +247,23 @@ class DefaultInstrumentDevice(InstrumentDevice, InstrumentLock):
     to YourDeviceHandler, use as boilerplate, and register it when the InstrumentServer
     is initialized.
     '''
-    def __init__(self, device_name, link_id):
-        super(DefaultInstrumentDevice, self).__init__(device_name, link_id)
-        #self.device_name = 'inst0'
+
+    def device_init(self):
         self.idn = 'python-vxi11-server', 'bbb', '1234', '567'
         self.result = 'empty'
+        return
     
-    def device_write(self, opaque_data):
+    def device_write(self, opaque_data, flags, io_timeout):
         error = vxi11.ERR_NO_ERROR
 
-        #opaque_data is a bytes array, so decode it correclty
+        #opaque_data is a bytes array, so decode it correctly
         cmd=opaque_data.decode("ascii")
         
         if cmd == '*IDN?':
             mfg, model, sn, fw = self.idn
             self.result = "{},{},{},{}".format(mfg, model, sn, fw)
         elif cmd  == '*DEVICE_LIST?':
-            devs = self.device_list()
+            devs = self.device_list
             self.result = ''
             isFirst = True
             for dev in devs:
@@ -319,7 +278,11 @@ class DefaultInstrumentDevice(InstrumentDevice, InstrumentLock):
         logger.info("%s: device_write(): %s %s", self.name(), cmd , self.result)
         return error
     
-    def device_read(self):
+    def device_read(self, request_size, term_char, flags, io_timeout):
         error = vxi11.ERR_NO_ERROR
-        #device-read returns opaque_data so encode it correclty
-        return error, self.result.encode("ascii")
+        reason = ReadRespReason.END
+
+        #device-read returns opaque_data so encode it correctly
+        opaque_data = self.result.encode("ascii")
+        
+        return error, reason, opaque_data

--- a/vxi11_server/instrument_server.py
+++ b/vxi11_server/instrument_server.py
@@ -70,26 +70,85 @@ class LockedIncrementer(object):
         finally:
             self.lock.release()
             
-class Registry(object):
+class DeviceLock(object):
+    # timeout not implemented.
+    def __init__(self, device_name):
+        self.device_name = device_name
+        self.lock = threading.Lock()
+        self.lock_id = 0
+        return
+    
+    def is_open(self, link_id, flags, timeout):
+        return self.lock_id == 0 or self.lock_id == link_id
+    
+    def is_locked(self):
+        return self.lock_id != 0
+    
+    def acquire(self, link_id, flags,lock_timeout):
+        logger.debug('locking device: %s', self.device_name)
+
+        self.lock.acquire()
+        try:
+            if self.lock_id == 0:
+                self.lock_id = link_id
+        finally:
+            self.lock.release()
+
+        return self.is_locked() and self.is_open(link_id, 0, 0)
+
+    def release(self, link_id):
+        logger.debug('unlocking device: %s', self.device_name)
+        if self.lock_id == link_id:
+            self.lock_id = 0
+            return True
+        return False
+    
+class DeviceItem(object):
+    def __init__(self, device_class):
+        self.device_class = device_class
+        self.lock = None
+        return
+    
+class DeviceRegistry(object):
+    _next_device_index = 0
+    _registry = {}
+
     def __init__(self):
-        registry = {}
+        pass
+    
+    def register(self, name, device_class):
+        if name is None:
+            while 'inst' +  str(self._next_device_index) in self._registry:
+                self._next_device_index += 1
+            name = 'inst' +  str(self._next_device_index)
+
+        if name in self._registry:
+            raise KeyError
+
+        item = DeviceItem(device_class)
+        item.lock = DeviceLock(name)
+        
+        self._registry[name] = item
+        
         return
     
-    def add(self, key, item):
-        self._device_class_registry[key] = item
-        return
-    
-    def remove(self, key):
-        del self._device_class_registry[key]
-        return
-    
-    def list(self):
-        return self._device_class_registry.keys()
-    
-    
+    def remove(self, name):
+        del self._registry[name]
+
+    def directory(self):
+        return self._registry.keys()
+
+    def factory(self, name):
+        item = self._registry[name]
+
+        device = item.device_class(name, item.lock)
+        device.device_list = self.directory()
+        
+        return device
+        
 class Vxi11Server(socketserver.ThreadingMixIn, rpc.TCPServer):
     _next_device_index = 0
-    _device_class_registry = {}
+    _device_registry = DeviceRegistry()
     _link_registry = {}
 
     def __init__(self, host, prog, vers, port, handler_class):
@@ -100,7 +159,7 @@ class Vxi11Server(socketserver.ThreadingMixIn, rpc.TCPServer):
     # move device_class_registry, link_create/delete to CoreHandler?
     def link_create(self, device_name):        
         # create and initialize an instance of the device handler registered to device_name
-        device_instance = self._device_class_registry[device_name](device_name, link_id)
+        device_instance = self._device_registry.factory(device_name)
         
         # and register it to a new link_id
         link_id = self.lid_gen.next()
@@ -127,20 +186,14 @@ class Vxi11Server(socketserver.ThreadingMixIn, rpc.TCPServer):
 
     # should the device registry be moved to the core server?
     def device_register(self, name, device_class):
-        if name is None:
-            while 'inst' +  str(self._next_device_index) in self._device_class_registry:
-                self._next_device_index += 1
-            name = 'inst' +  str(self._next_device_index)
-
-        if name in self._device_class_registry:
-            raise KeyError
-        self._device_class_registry[name] = device_class
+        self._device_registry.register(name, device_class)
         
     def device_unregister(self, name):
-        del self._device_class_registry[name]
-
-    def device_list(self):
-        return self._device_class_registry.keys()
+        self._device_registry.remove(name)
+        return
+    
+    # def device_list(self):
+    #     return self._device_registry.directory()
     
 class Vxi11Handler(rpc.RPCRequestHandler):
     def addpackers(self):
@@ -169,7 +222,8 @@ class Vxi11CoreServer(Vxi11Server):
         Vxi11Server.__init__(self, '', vxi11.DEVICE_CORE_PROG, vxi11.DEVICE_CORE_VERS, 0, Vxi11CoreHandler)
         self.abort_port = abort_port
         return
-    
+
+
 class Vxi11CoreHandler(Vxi11Handler):
         
     def handle_10(self):
@@ -183,24 +237,24 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('CREATE_LINK %s' ,params)
 
         self.link_id = 0
-        abort_port = 0
-        #maxlen = 1024
         error = vxi11.ERR_NO_ERROR
         
         try:
-            logger.debug("Device name \"%s\"", device_name)
+            logger.debug('Device name "%s"', device_name)
             self.link_id, self.device = self.server.link_create(device_name)
         except KeyError:
             error = vxi11.ERR_DEVICE_NOT_ACCESSIBLE
             logger.debug("Create link failed")
         else:
+            self.device.device_init()
             if lock_device == True:
                 flags = 0
-                error = self.device.device_lock(flags, lock_timeout)
-            if device_name == 'inst0':
-                self.device.device_list = self.server.device_list
-            abort_port = self.server.abort_port
+                error = self.device.lock.acquire(self.link_id, flags, lock_timeout)
 
+        abort_port = 0
+        if error == vxi11.ERR_NO_ERROR:
+            abort_port = self.server.abort_port
+            
         result = (error, self.link_id, abort_port, MAX_RECEIVE_SIZE)
         self.turn_around()
         self.packer.pack_create_link_resp(result)
@@ -212,18 +266,18 @@ class Vxi11CoreHandler(Vxi11Handler):
         params = self.unpacker.unpack_device_link()
         link_id = params
 
-        error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
         else:
             logger.debug('DESTROY_LINK %s to %s', link_id, self.device.device_name)
-            if self.device.is_locked():
-                self.device.device_unlock() 
             # first disable interrupt handling of the device if it was on
             self.device.device_enable_srq(False,None)
             self.device.destroy_intr_chan()
+
+            self.device.lock.release(link_id) 
+
             # now remove link and therefore delete everything.
-            self.server.link_delete(self.link_id)
+            self.server.link_delete(link_id)
             error = vxi11.ERR_NO_ERROR
             
         self.turn_around()
@@ -241,12 +295,12 @@ class Vxi11CoreHandler(Vxi11Handler):
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
         elif len(opaque_data) > MAX_RECEIVE_SIZE:
             error = vxi11.ERR_PARAMETER_ERROR
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error = self.device.device_write(opaque_data)
+            error = self.device.device_write(opaque_data, flags, io_timeout)
             
-        if error != 0:
+        if error != vxi11.ERR_NO_ERROR:
             result = (error, 0)
         else:
             result = (error, len(opaque_data))
@@ -260,17 +314,16 @@ class Vxi11CoreHandler(Vxi11Handler):
         
         params = self.unpacker.unpack_device_read_parms()
         logger.debug('DEVICE_READ %s', params)
-        link_id, request_size, io_timeout, lock_timeout, flags, termChar = params
+        link_id, request_size, io_timeout, lock_timeout, flags, term_char = params
 
         opaque_data = b''
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error, opaque_data = self.device.device_read()
+            error, reason, opaque_data = self.device.device_read(request_size, term_char, flags, io_timeout)
 
-        reason = vxi11.RX_END
         result = (error, reason, opaque_data)
         self.turn_around()
         self.packer.pack_device_read_resp(result)
@@ -283,14 +336,13 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_READSTB %s', params)
         link_id, flags, lock_timeout, io_timeout = params
 
-        error = vxi11.ERR_NO_ERROR
         stb=0
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error,stb = self.device.device_readstb( flags, lock_timeout, io_timeout)
+            error,stb = self.device.device_readstb( flags, io_timeout)
             
         result = (error, stb)
         self.turn_around()
@@ -304,13 +356,12 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_TRIGGER %s', params)
         link_id, flags, lock_timeout, io_timeout = params
 
-        error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error = self.device.device_trigger(flags, lock_timeout, io_timeout)
+            error = self.device.device_trigger(flags, io_timeout)
             
         self.turn_around()
         self.packer.pack_device_error(error)
@@ -323,13 +374,12 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_CLEAR %s', params)
         link_id, flags, lock_timeout, io_timeout = params
 
-        error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error = self.device.device_clear(flags, lock_timeout, io_timeout)
+            error = self.device.device_clear(flags, io_timeout)
             
         self.turn_around()
         self.packer.pack_device_error(error)
@@ -342,13 +392,12 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_REMOTE %s', params)
         link_id, flags, lock_timeout, io_timeout = params
 
-        error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error = self.device.device_remote(flags, lock_timeout, io_timeout)
+            error = self.device.device_remote(flags, io_timeout)
             
         self.turn_around()
         self.packer.pack_device_error(error)
@@ -361,13 +410,12 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_LOCAL %s', params)
         link_id, flags, lock_timeout, io_timeout = params
 
-        error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error = self.device.device_local(flags, lock_timeout, io_timeout)
+            error = self.device.device_local(flags, io_timeout)
             
         self.turn_around()
         self.packer.pack_device_error(error)
@@ -380,13 +428,12 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_LOCK %s', params)
         link_id, flags, lock_timeout = params
 
-        error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif self.device.is_locked():
-            error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
+        elif self.device.lock.acquire(link_id, flags, lock_timeout):
+            error = vxi11.ERR_NO_ERROR
         else:
-            error = self.device.device_lock(flags, lock_timeout)
+            error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
             
         self.turn_around()
         self.packer.pack_device_error(error)
@@ -397,16 +444,17 @@ class Vxi11CoreHandler(Vxi11Handler):
         
         params = self.unpacker.unpack_device_link()
         logger.debug('DEVICE_UNLOCK %s', params)
- 	link_id = params
+        link_id = params
  
-       	error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
-            error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
+        elif not self.device.lock.is_locked():
+            error = vxi11.ERR_NO_LOCK_HELD_BY_THIS_LINK
+        elif self.device.lock.release(link_id):
+       	    error = vxi11.ERR_NO_ERROR
         else:
-            error = self.device.device_unlock(flags, lock_timeout, io_timeout)
-            
+            error = vxi11.ERR_NO_LOCK_HELD_BY_THIS_LINK
+
         self.turn_around()
         self.packer.pack_device_error(error)
         return
@@ -443,11 +491,8 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_ENABLE_SRQ %s', params)
         link_id, enable, handle = params
 
-        error = vxi11.ERR_NO_ERROR
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
-            error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
             error = self.device.device_enable_srq(enable,handle)
 
@@ -462,14 +507,13 @@ class Vxi11CoreHandler(Vxi11Handler):
         logger.debug('DEVICE_DOCMD %s', params)
         link_id, flags, io_timeout, lock_timeout, cmd, network_order, data_size, opaque_data_in = params
 
-        error = vxi11.ERR_NO_ERROR
         opaque_data_out = b""
         if link_id != self.link_id:
             error = vxi11.ERR_INVALID_LINK_IDENTIFIER
-        elif not self.device.has_lock():
+        elif not self.device.lock.is_open(link_id, flags, lock_timeout):
             error = vxi11.ERR_DEVICE_LOCKED_BY_ANOTHER_LINK
         else:
-            error, opaque_data_out = self.device.device_docmd(flags, io_timeout, lock_timeout, cmd, network_order, data_size, opaque_data_in)
+            error, opaque_data_out = self.device.device_docmd(flags, io_timeout, cmd, network_order, data_size, opaque_data_in)
             
         result = error, opaque_data_out
         self.turn_around()


### PR DESCRIPTION
Main goal is to add preliminary lock support.  Lock timeouts still need to be implemented.

- added device_init() to InstrumentDevice.  Override it instead of \_\_init\_\_()  if you want to avoid the responsibility for calling super()  
- expanded device_read and device_write functions to include flags etc.  Should look into having the CoreHandler chunk opaque data up into request_size blocks.
- removed reference to instr0 from CoreHandler.
- and others

