### PR TITLE
Fix: Trim SCPI commands to allow *IDN?\n and similar inputs

### DIFF
--- a/vxi11_server/instrument_device.py
+++ b/vxi11_server/instrument_device.py
@@ -267,7 +267,7 @@ class DefaultInstrumentDevice(InstrumentDevice):
         error = vxi11.ERR_NO_ERROR
 
         #opaque_data is a bytes array, so decode it correctly
-        cmd=opaque_data.decode("ascii")
+        cmd=opaque_data.decode("ascii").strip()
         
         if cmd == '*IDN?':
             mfg, model, sn, fw = self.idn


### PR DESCRIPTION
### Summary

This pull request fixes an issue where SCPI commands such as `*IDN?\n` or `*IDN?\r\n` were not being recognized due to trailing newline characters.

Many SCPI clients — including Keysight IO Libraries and NI-VISA — automatically append newline characters when sending commands. Trimming the incoming command string ensures broader compatibility and expected behavior.

### Changes

- Updated `device_write()` to use `.strip()` on incoming SCPI command strings.
- Now handles typical command formats like `*IDN?\n` correctly.

### Related Issue

Fixes #25

### Notes

Tested using **Keysight IO Libraries (on Windows 11)** with the **server running on Raspberry Pi 5** — works as expected.  

Thanks again for maintaining this great project!